### PR TITLE
Add a stricter mime type filter

### DIFF
--- a/app/src/main/java/io/rebble/charon/MainActivity.kt
+++ b/app/src/main/java/io/rebble/charon/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun chooseFile() {
-        val type = "*/*"
+        val type = "application/zip"
         val i = Intent(Intent.ACTION_GET_CONTENT)
         i.type = type
         startActivityForResult(Intent.createChooser(i, getString(R.string.select_file)), OPEN_REQUEST_CODE)

--- a/app/src/main/java/io/rebble/charon/MainActivity.kt
+++ b/app/src/main/java/io/rebble/charon/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun chooseFile() {
-        val type = "application/*" // That's the mime-type Android tells me for the PBW/PBZ/PBL files 
+        val type = "application/*" 
         val i = Intent(Intent.ACTION_GET_CONTENT)
         i.type = type
         startActivityForResult(Intent.createChooser(i, getString(R.string.select_file)), OPEN_REQUEST_CODE)

--- a/app/src/main/java/io/rebble/charon/MainActivity.kt
+++ b/app/src/main/java/io/rebble/charon/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun chooseFile() {
-        val type = "application/zip"
+        val type = "application/*" // That's the mime-type Android tells me for the PBW/PBZ/PBL files 
         val i = Intent(Intent.ACTION_GET_CONTENT)
         i.type = type
         startActivityForResult(Intent.createChooser(i, getString(R.string.select_file)), OPEN_REQUEST_CODE)


### PR DESCRIPTION
This removes some of the files that shouldn't be shown in the file manager, eg: videos, images. On Android the mime-type for a PBW and a PBZ is `application/*` whereas on desktop it's `application/zip`.